### PR TITLE
delete key if get()  is undefined

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -18,6 +18,7 @@ module.exports = class WeakValue extends Map {
   }
   get(key) {
     const ref = super.get(key);
+    if (ref && ref.deref() === undefined && this.#delete(key)) return;
     return ref && ref.deref();
   }
   set(key, value) {

--- a/esm/index.js
+++ b/esm/index.js
@@ -17,6 +17,7 @@ export default class WeakValue extends Map {
   }
   get(key) {
     const ref = super.get(key);
+    if (ref && ref.deref() === undefined && this.#delete(key)) return;
     return ref && ref.deref();
   }
   set(key, value) {


### PR DESCRIPTION
If evaluation of get() is undefined, wouldn't it be better to change it to erase it from the map?